### PR TITLE
fix(claude): write compose release to real path, not inside .compose/

### DIFF
--- a/claude/commands/compose.md
+++ b/claude/commands/compose.md
@@ -202,9 +202,13 @@ Apply `distill` skill to any section flagged for compression. Update status to `
 
 ### Stage 7 — Release
 
-Write final document to `release/doc.md`.
+Determine the release path before writing:
+- If invoked with an existing file path (`/compose path/to/doc.md`): write the release back to that path, overwriting it.
+- If invoked with a description: derive a slug from the thesis (e.g., `eng-org-consolidation-memo.md`) and write to the current working directory, or a path the user specifies.
 
-`release/doc.md` contains only the document — no status headers, no `[^Sxxx]` annotations (these live in sources.md), no metadata beyond what belongs in the document itself. Where citations are appropriate for the audience (external docs, academic-style memos), convert `[^Sxxx]` to standard footnotes with the source URL.
+Write the release to that path — not inside `.compose/`. The `.compose/` directory is scaffolding (artifact trail, sources, critique); it stays hidden. The released document is a normal file at a real path.
+
+The release document contains only the document — no status headers, no `[^Sxxx]` or `[^org:]` annotations (these live in sources.md), no metadata beyond what belongs in the document itself. Where citations are appropriate for the audience (external docs, academic-style memos), convert `[^Sxxx]` references to standard footnotes with the source URL from sources.md.
 
 ## Transition Rules
 


### PR DESCRIPTION
Stage 7 of `/compose` was writing the release document to `.compose/TIMESTAMP/release/doc.md` — inside a hidden directory, which signals "draft scaffolding" rather than "released document."

## Change

Stage 7 now determines a real output path before writing:
- If invoked with an existing file path: write back to that path
- If invoked with a description: derive a slug from the thesis and write to CWD

The `.compose/` directory remains as the hidden artifact trail (brief, sources, critique). The released document lands at a visible, normal path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UX6UfiHMLPNQawFiqRJqVQ)_