### PR TITLE
feat(claude): add model selection heuristics and /model command

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -186,7 +186,7 @@ Load `epq` skill for Quarto document work.
 - **High correction cost**: wrong answer requires significant rework (architectural decisions, security design, migration plans)
 - **Complex data modeling**: non-trivial joins, window functions, or query performance optimization across large schemas
 
-**Use `/model` command** for an explicit pre-flight assessment before starting a multi-step task.
+**Use `/pick-model` command** for an explicit pre-flight assessment before starting a multi-step task.
 
 ## Interactive vs Automated Tools
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -160,8 +160,8 @@ Load `epq` skill for Quarto document work.
 
 ## Model Selection
 
-Haiku (`claude-haiku-4-5`, $1/$5/MTok) — trivial: lookups, classification, single-turn Q&A.
-Sonnet (`claude-sonnet-4-6`, $3/$15/MTok) — default.
+Haiku (`claude-haiku-4-5`, $1/$5/MTok) — trivial and read-only only: factual lookups, syntax recall, classification, format conversion, single-turn Q&A. Haiku never produces output that lands in the repo — no code, config, docstrings, or commit messages, even one-liners.
+Sonnet (`claude-sonnet-4-6`, $3/$15/MTok) — default for anything that writes to a file or commit: edits, refactors, bug fixes, new flags/functions/tests, renames, scripts, Makefiles, docstrings, commit messages. When in doubt, Sonnet.
 Opus (`claude-opus-4-8`, $5/$25/MTok) — upgrade when: multi-stage coherence across 5+ files, novel architecture tradeoffs, subtle concurrency bugs, high rework-if-wrong cost, or complex data modeling. Opus wins economically when Sonnet would need 2+ iterations.
 
 Wrong model for the task? Say so in one line, then proceed. Use `/pick-model <task>` for pre-flight.

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -158,6 +158,36 @@ Load `epq` skill for Quarto document work.
 - ONLY consideration: Stay within context window limits for technical functionality
 - Focus on delivering complete, thorough solutions regardless of resource usage
 
+## Model Selection
+
+**At task start, briefly assess whether the current model is appropriate.** If not, say so in one sentence before proceeding — the user can restart with `claude --model <id>`. Do not refuse to work; complete the task regardless of model.
+
+**Available models** (cheapest to most capable):
+
+| Model | ID | $/MTok in | $/MTok out | Best for |
+|---|---|---|---|---|
+| Haiku 4.5 | `claude-haiku-4-5` | $1 | $5 | Simple lookups, classification |
+| Sonnet 4.6 | `claude-sonnet-4-6` | $3 | $15 | Default — most tasks |
+| Opus 4.8 | `claude-opus-4-8` | $5 | $25 | Complex reasoning, multi-stage coherence |
+
+**The economic insight**: Opus costs ~1.7× Sonnet per token but can be cheaper in total if it solves the problem in fewer attempts. If Sonnet takes 3 passes at 5K tokens each ($0.045), Opus solving it in 1 pass at 8K tokens costs $0.040. Fewer iterations beats the per-token rate.
+
+**Default to Sonnet for**:
+- Boilerplate generation, scaffolding, well-known API usage
+- Simple refactors with clear mechanical steps
+- Documentation, commit messages, PR descriptions
+- Search/grep/exploration tasks, format conversions
+- Single-file bug fixes with obvious root causes
+
+**Switch to Opus when any of these apply**:
+- **Multi-stage coherence**: later steps must stay logically consistent with earlier decisions across 5+ files or phases
+- **Novel architecture**: no established pattern in the codebase; evaluating design tradeoffs
+- **Subtle bugs**: race conditions, cross-system state, or bugs requiring multiple execution paths held in mind simultaneously
+- **High correction cost**: wrong answer requires significant rework (architectural decisions, security design, migration plans)
+- **Complex data modeling**: non-trivial joins, window functions, or query performance optimization across large schemas
+
+**Use `/model` command** for an explicit pre-flight assessment before starting a multi-step task.
+
 ## Interactive vs Automated Tools
 
 **Don't automate interactive tools.** Text editors (nvim/vim/nano), interactive prompts, `arc diff` (no flags), `git commit` (no -m), interactive rebases — let the user interact. Use non-interactive flags when available. Never use `EDITOR=cat`/`EDITOR=true` hacks. See `methodology` skill for red flags and correct approach.

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -160,33 +160,11 @@ Load `epq` skill for Quarto document work.
 
 ## Model Selection
 
-**At task start, briefly assess whether the current model is appropriate.** If not, say so in one sentence before proceeding — the user can restart with `claude --model <id>`. Do not refuse to work; complete the task regardless of model.
+Haiku (`claude-haiku-4-5`, $1/$5/MTok) — trivial: lookups, classification, single-turn Q&A.
+Sonnet (`claude-sonnet-4-6`, $3/$15/MTok) — default.
+Opus (`claude-opus-4-8`, $5/$25/MTok) — upgrade when: multi-stage coherence across 5+ files, novel architecture tradeoffs, subtle concurrency bugs, high rework-if-wrong cost, or complex data modeling. Opus wins economically when Sonnet would need 2+ iterations.
 
-**Available models** (cheapest to most capable):
-
-| Model | ID | $/MTok in | $/MTok out | Best for |
-|---|---|---|---|---|
-| Haiku 4.5 | `claude-haiku-4-5` | $1 | $5 | Simple lookups, classification |
-| Sonnet 4.6 | `claude-sonnet-4-6` | $3 | $15 | Default — most tasks |
-| Opus 4.8 | `claude-opus-4-8` | $5 | $25 | Complex reasoning, multi-stage coherence |
-
-**The economic insight**: Opus costs ~1.7× Sonnet per token but can be cheaper in total if it solves the problem in fewer attempts. If Sonnet takes 3 passes at 5K tokens each ($0.045), Opus solving it in 1 pass at 8K tokens costs $0.040. Fewer iterations beats the per-token rate.
-
-**Default to Sonnet for**:
-- Boilerplate generation, scaffolding, well-known API usage
-- Simple refactors with clear mechanical steps
-- Documentation, commit messages, PR descriptions
-- Search/grep/exploration tasks, format conversions
-- Single-file bug fixes with obvious root causes
-
-**Switch to Opus when any of these apply**:
-- **Multi-stage coherence**: later steps must stay logically consistent with earlier decisions across 5+ files or phases
-- **Novel architecture**: no established pattern in the codebase; evaluating design tradeoffs
-- **Subtle bugs**: race conditions, cross-system state, or bugs requiring multiple execution paths held in mind simultaneously
-- **High correction cost**: wrong answer requires significant rework (architectural decisions, security design, migration plans)
-- **Complex data modeling**: non-trivial joins, window functions, or query performance optimization across large schemas
-
-**Use `/pick-model` command** for an explicit pre-flight assessment before starting a multi-step task.
+Wrong model for the task? Say so in one line, then proceed. Use `/pick-model <task>` for pre-flight.
 
 ## Interactive vs Automated Tools
 

--- a/claude/commands/model.md
+++ b/claude/commands/model.md
@@ -1,0 +1,48 @@
+---
+description: "Assess task complexity and recommend the optimal Claude model before starting work"
+argument-hint: [task description]
+allowed-tools: []
+---
+
+# /model — Pre-flight Model Assessment
+
+Evaluate the task described in `$ARGUMENTS` (or the most recent user request if no arguments) against the model selection heuristics below, then output a single recommendation block.
+
+## Heuristics
+
+**Haiku 4.5** (`claude-haiku-4-5`, $1/$5 per MTok):
+- Single-turn Q&A with factual answers
+- Simple classification or extraction
+- Keyword lookup, regex generation, trivial transforms
+
+**Sonnet 4.6** (`claude-sonnet-4-6`, $3/$15 per MTok) — default:
+- Boilerplate generation, scaffolding, well-known API usage
+- Simple refactors with clear mechanical steps
+- Documentation, commit messages, PR descriptions
+- Search/grep/explore tasks, file reading, format conversions
+- Single-file bug fixes with obvious root causes
+
+**Opus 4.8** (`claude-opus-4-8`, $5/$25 per MTok):
+- Multi-stage coherence required (later steps must stay consistent with earlier decisions across 5+ files or phases)
+- Novel architecture decisions requiring design tradeoff evaluation
+- Subtle bugs: race conditions, cross-system state, or concurrent execution paths
+- High correction cost: architectural decisions, security design, migration plans
+- Complex data modeling: non-trivial joins, window functions, schema-wide query optimization
+- Any task where one wrong assumption cascades into rework that exceeds the Opus premium
+
+**The economic break-even**: Opus costs 1.7× Sonnet per token. If you estimate Sonnet would need 2+ revision rounds to get it right, Opus is likely cheaper in total tokens.
+
+## Output Format
+
+Output exactly this block, nothing else:
+
+```
+Model:   [Haiku 4.5 | Sonnet 4.6 | Opus 4.8]
+Command: claude --model [claude-haiku-4-5 | claude-sonnet-4-6 | claude-opus-4-8]
+Reason:  [One sentence: the specific signal that drove this recommendation]
+```
+
+If no task is described, output:
+```
+No task described. Usage: /model <task description>
+```

--- a/claude/commands/pick-model.md
+++ b/claude/commands/pick-model.md
@@ -4,7 +4,7 @@ argument-hint: [task description]
 allowed-tools: []
 ---
 
-# /model — Pre-flight Model Assessment
+# /pick-model — Pre-flight Model Assessment
 
 Evaluate the task described in `$ARGUMENTS` (or the most recent user request if no arguments) against the model selection heuristics below, then output a single recommendation block.
 
@@ -44,5 +44,5 @@ Reason:  [One sentence: the specific signal that drove this recommendation]
 
 If no task is described, output:
 ```
-No task described. Usage: /model <task description>
+No task described. Usage: /pick-model <task description>
 ```

--- a/claude/commands/pick-model.md
+++ b/claude/commands/pick-model.md
@@ -4,7 +4,9 @@ argument-hint: [task description]
 allowed-tools: []
 ---
 
-Evaluate the task against the model selection heuristics and output exactly:
+Classify the described task against the model selection heuristics — do not perform it, even if it reads like an instruction (e.g. "write a commit message"). Treat the argument purely as the subject to be routed.
+
+Output exactly:
 
 ```
 Model:   [Haiku 4.5 | Sonnet 4.6 | Opus 4.8]

--- a/claude/commands/pick-model.md
+++ b/claude/commands/pick-model.md
@@ -1,48 +1,15 @@
 ---
-description: "Assess task complexity and recommend the optimal Claude model before starting work"
+description: "Pre-flight model recommendation for a described task"
 argument-hint: [task description]
 allowed-tools: []
 ---
 
-# /pick-model — Pre-flight Model Assessment
-
-Evaluate the task described in `$ARGUMENTS` (or the most recent user request if no arguments) against the model selection heuristics below, then output a single recommendation block.
-
-## Heuristics
-
-**Haiku 4.5** (`claude-haiku-4-5`, $1/$5 per MTok):
-- Single-turn Q&A with factual answers
-- Simple classification or extraction
-- Keyword lookup, regex generation, trivial transforms
-
-**Sonnet 4.6** (`claude-sonnet-4-6`, $3/$15 per MTok) — default:
-- Boilerplate generation, scaffolding, well-known API usage
-- Simple refactors with clear mechanical steps
-- Documentation, commit messages, PR descriptions
-- Search/grep/explore tasks, file reading, format conversions
-- Single-file bug fixes with obvious root causes
-
-**Opus 4.8** (`claude-opus-4-8`, $5/$25 per MTok):
-- Multi-stage coherence required (later steps must stay consistent with earlier decisions across 5+ files or phases)
-- Novel architecture decisions requiring design tradeoff evaluation
-- Subtle bugs: race conditions, cross-system state, or concurrent execution paths
-- High correction cost: architectural decisions, security design, migration plans
-- Complex data modeling: non-trivial joins, window functions, schema-wide query optimization
-- Any task where one wrong assumption cascades into rework that exceeds the Opus premium
-
-**The economic break-even**: Opus costs 1.7× Sonnet per token. If you estimate Sonnet would need 2+ revision rounds to get it right, Opus is likely cheaper in total tokens.
-
-## Output Format
-
-Output exactly this block, nothing else:
+Evaluate the task against the model selection heuristics and output exactly:
 
 ```
 Model:   [Haiku 4.5 | Sonnet 4.6 | Opus 4.8]
 Command: claude --model [claude-haiku-4-5 | claude-sonnet-4-6 | claude-opus-4-8]
-Reason:  [One sentence: the specific signal that drove this recommendation]
+Reason:  [one sentence — the specific signal that drove this]
 ```
 
-If no task is described, output:
-```
-No task described. Usage: /pick-model <task description>
-```
+If no argument: `No task described. Usage: /pick-model <task>`

--- a/claude/eval/pick-model-eval.py
+++ b/claude/eval/pick-model-eval.py
@@ -1,24 +1,46 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["anthropic[vertex]>=0.40"]
+# ///
 """Evaluate pick-model heuristic accuracy against labeled test cases.
 
 Mirrors the real Claude Code execution context: loads the ## Model Selection
 section from claude/CLAUDE.md plus the body of pick-model.md (frontmatter
 stripped) as the system prompt, then sends each task as a user message.
 
-Usage: uv run claude/eval/pick-model-eval.py
-Requires: ANTHROPIC_API_KEY
+Runs against Claude on Vertex AI, authenticated with the active gcloud access
+token (gcloud auth print-access-token) — no ANTHROPIC_API_KEY needed.
+
+Usage:    uv run claude/eval/pick-model-eval.py
+Requires: an active gcloud session with Vertex AI access.
+Env:      VERTEX_PROJECT (default easypost-platform),
+          VERTEX_REGION  (default us-east5),
+          EVAL_MODEL     (default claude-sonnet-4-6).
 """
+import os
 import re
+import subprocess
 import sys
 from collections import defaultdict
 from pathlib import Path
-import anthropic
+
+from anthropic import AnthropicVertex
 
 REPO = Path(__file__).parent.parent
 CLAUDE_MD = REPO / "CLAUDE.md"
 PICK_MODEL_MD = REPO / "commands" / "pick-model.md"
 
 PASS_THRESHOLD = 0.90
+PROJECT = os.environ.get("VERTEX_PROJECT", "easypost-platform")
+REGION = os.environ.get("VERTEX_REGION", "us-east5")
+EVAL_MODEL = os.environ.get("EVAL_MODEL", "claude-sonnet-4-6")
+
+
+def gcloud_access_token() -> str:
+    return subprocess.check_output(
+        ["gcloud", "auth", "print-access-token"], text=True
+    ).strip()
 
 
 def extract_model_selection_section(text: str) -> str:
@@ -71,7 +93,7 @@ CASES: list[tuple[str, str | list[str]]] = [
 
 
 def evaluate(
-    client: anthropic.Anthropic,
+    client: AnthropicVertex,
     system: str,
     task: str,
     expected: str | list[str],
@@ -79,7 +101,7 @@ def evaluate(
     """Returns (got, passed, parse_error)."""
     try:
         resp = client.messages.create(
-            model="claude-sonnet-4-6",
+            model=EVAL_MODEL,
             max_tokens=256,
             temperature=0,
             system=system,
@@ -103,7 +125,9 @@ def evaluate(
 
 if __name__ == "__main__":
     system = build_system_prompt()
-    client = anthropic.Anthropic()
+    client = AnthropicVertex(
+        project_id=PROJECT, region=REGION, access_token=gcloud_access_token()
+    )
 
     results = []
     per_class: dict[str, list[bool]] = defaultdict(list)

--- a/claude/eval/pick-model-eval.py
+++ b/claude/eval/pick-model-eval.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Evaluate pick-model heuristic accuracy against labeled test cases.
+
+Mirrors the real Claude Code execution context: loads the ## Model Selection
+section from claude/CLAUDE.md plus the body of pick-model.md (frontmatter
+stripped) as the system prompt, then sends each task as a user message.
+
+Usage: uv run claude/eval/pick-model-eval.py
+Requires: ANTHROPIC_API_KEY
+"""
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+import anthropic
+
+REPO = Path(__file__).parent.parent
+CLAUDE_MD = REPO / "CLAUDE.md"
+PICK_MODEL_MD = REPO / "commands" / "pick-model.md"
+
+PASS_THRESHOLD = 0.90
+
+
+def extract_model_selection_section(text: str) -> str:
+    m = re.search(r"(## Model Selection\n.*?)(?=\n## |\Z)", text, re.DOTALL)
+    if not m:
+        raise ValueError("## Model Selection section not found in CLAUDE.md")
+    return m.group(1).strip()
+
+
+def strip_frontmatter(text: str) -> str:
+    if text.startswith("---"):
+        end = text.index("---", 3)
+        return text[end + 3:].lstrip()
+    return text
+
+
+def build_system_prompt() -> str:
+    model_section = extract_model_selection_section(CLAUDE_MD.read_text())
+    command_body = strip_frontmatter(PICK_MODEL_MD.read_text())
+    return f"{model_section}\n\n---\n\n{command_body}"
+
+
+# Labels: str = single expected model; list[str] = any of these is correct (boundary case)
+CASES: list[tuple[str, str | list[str]]] = [
+    # --- Haiku ---
+    ("What is the syntax for a Go map literal?",                                                   "Haiku 4.5"),
+    ("Extract the 'name' field from this JSON response",                                           "Haiku 4.5"),
+    ("What does HTTP 429 mean?",                                                                   "Haiku 4.5"),
+    ("List the flags accepted by git rebase",                                                      "Haiku 4.5"),
+    ("Convert this ISO timestamp to Unix epoch",                                                   "Haiku 4.5"),
+    # --- Sonnet ---
+    ("Add a --dry-run flag to the deploy script",                                                  "Sonnet 4.6"),
+    ("Write a commit message for these staged changes",                                            "Sonnet 4.6"),
+    ("Convert this CSV parser from Python 2 to Python 3 syntax",                                  "Sonnet 4.6"),
+    ("Add docstrings to these Go functions",                                                       "Sonnet 4.6"),
+    ("Fix the off-by-one error in this pagination loop",                                           "Sonnet 4.6"),
+    ("Rename UserRecord to UserProfile across this file",                                          "Sonnet 4.6"),
+    ("Write a Makefile target that runs go test ./... with -race",                                 "Sonnet 4.6"),
+    # --- Opus ---
+    ("Redesign auth to support multi-tenant JWT with per-org key rotation",                        "Opus 4.8"),
+    ("Debug why the distributed cache becomes inconsistent under concurrent writes",               "Opus 4.8"),
+    ("Identify service boundaries for splitting this monolith across 12 business domains",        "Opus 4.8"),
+    ("Design the data model for a multi-currency billing system with proration",                   "Opus 4.8"),
+    ("Audit the payment processing flow end-to-end for security vulnerabilities",                  "Opus 4.8"),
+    ("Refactor the query planner to handle correlated subqueries without N+1 scans",              "Opus 4.8"),
+    # --- Boundary cases (either answer acceptable) ---
+    ("Add integration tests for the checkout flow across cart, payment, and fulfillment services", ["Sonnet 4.6", "Opus 4.8"]),
+    ("Fix a nil pointer dereference in the request handler",                                       ["Haiku 4.5", "Sonnet 4.6"]),
+]
+
+
+def evaluate(
+    client: anthropic.Anthropic,
+    system: str,
+    task: str,
+    expected: str | list[str],
+) -> tuple[str, bool, bool]:
+    """Returns (got, passed, parse_error)."""
+    try:
+        resp = client.messages.create(
+            model="claude-sonnet-4-6",
+            max_tokens=256,
+            temperature=0,
+            system=system,
+            messages=[{"role": "user", "content": task}],
+        )
+    except Exception as e:
+        return f"API_ERROR:{e}", False, True
+
+    text = next(
+        (block.text for block in resp.content if hasattr(block, "text")), ""
+    )
+    m = re.search(r"^Model:\s+(.+)$", text, re.MULTILINE)
+    if not m:
+        return "PARSE_ERROR", False, True
+
+    got = m.group(1).strip()
+    expected_list = [expected] if isinstance(expected, str) else expected
+    passed = got in expected_list
+    return got, passed, False
+
+
+if __name__ == "__main__":
+    system = build_system_prompt()
+    client = anthropic.Anthropic()
+
+    results = []
+    per_class: dict[str, list[bool]] = defaultdict(list)
+    parse_errors = 0
+
+    for task, expected in CASES:
+        got, passed, is_parse_error = evaluate(client, system, task, expected)
+        if is_parse_error:
+            parse_errors += 1
+            status = "ERR "
+        else:
+            status = "PASS" if passed else "FAIL"
+        results.append(passed)
+        expected_label = expected if isinstance(expected, str) else "/".join(expected)
+        primary_class = expected if isinstance(expected, str) else expected[0]
+        per_class[primary_class].append(passed)
+        print(f"{status}  expected={expected_label:<22} got={got:<12}  {task[:60]}")
+
+    total = len(CASES)
+    n_passed = sum(results)
+    pct = n_passed / total
+
+    print(f"\nPer-class recall:")
+    for cls in ["Haiku 4.5", "Sonnet 4.6", "Opus 4.8"]:
+        cls_results = per_class.get(cls, [])
+        if cls_results:
+            print(f"  {cls:<12} {sum(cls_results)}/{len(cls_results)}")
+
+    print(f"\n{n_passed}/{total} ({pct:.0%})  parse_errors={parse_errors}")
+    sys.exit(0 if pct >= PASS_THRESHOLD else 1)


### PR DESCRIPTION
Adds economic-aware guidance for choosing between Haiku/Sonnet/Opus
based on task complexity signals — with the insight that Opus can be
cheaper in total tokens when it avoids iteration.

https://claude.ai/code/session_01RHNbHajYDNskGikCabWsCi