### PR TITLE
Archive idle Claude tmux windows to later, then close after 24 hours

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -49,6 +49,15 @@
             "command": "$HOME/.files/bin/claude-session-start-hook"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.files/bin/claude-tmux-later\" hook",
+            "timeout": 30
+          }
+        ]
       }
     ],
     "Notification": [
@@ -120,6 +129,15 @@
             "command": "$HOME/.files/bin/claude-tool-start-hook"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.files/bin/claude-tmux-later\" hook",
+            "timeout": 30
+          }
+        ]
       }
     ],
     "Stop": [
@@ -133,6 +151,103 @@
           {
             "type": "command",
             "command": "$HOME/.files/bin/claude-stop-hook"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.files/bin/claude-tmux-later\" hook",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.files/bin/claude-tmux-later\" hook",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.files/bin/claude-tmux-later\" hook",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.files/bin/claude-tmux-later\" hook",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.files/bin/claude-tmux-later\" hook",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.files/bin/claude-tmux-later\" hook",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.files/bin/claude-tmux-later\" hook",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.files/bin/claude-tmux-later\" hook",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$HOME/.files/bin/claude-tmux-later\" hook",
+            "timeout": 30
           }
         ]
       }

--- a/.github/workflows/claude-tmux-later.yml
+++ b/.github/workflows/claude-tmux-later.yml
@@ -1,0 +1,46 @@
+name: Claude tmux idle cleanup
+
+on:
+  pull_request:
+    paths:
+      - 'bin/claude-tmux-later*'
+      - '.claude/settings.json'
+      - 'claude/tmux-later.json'
+      - 'Makefile'
+      - '.github/workflows/claude-tmux-later.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'bin/claude-tmux-later*'
+      - '.claude/settings.json'
+      - 'claude/tmux-later.json'
+      - 'Makefile'
+      - '.github/workflows/claude-tmux-later.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install tmux on Linux
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y tmux
+      - name: Install tmux on macOS
+        if: runner.os == 'macOS'
+        run: command -v tmux || brew install tmux
+      - run: python -m pip install pytest
+      - name: Unit and isolated live-tmux tests
+        run: python -m pytest -v bin/*_test.py
+        env:
+          REQUIRE_TMUX_TESTS: '1'

--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,8 @@ superwhisper:
 claude:
 	@mkdir -p $(HOME)/.claude
 	@mkdir -p $(HOME)/.claude/local
+	@mkdir -p $(HOME)/.config/claude-tmux-later
+	@ln -fs $(DOTFILES)/claude/tmux-later.json $(HOME)/.config/claude-tmux-later/config.json
 	@ln -fs $(DOTFILES)/.claude/settings.json $(HOME)/.claude/settings.json
 	@ln -fs $(DOTFILES)/claude/CLAUDE.md $(HOME)/.claude/CLAUDE.md
 	@ln -fs $(DOTFILES)/claude/CONSTITUTION.md $(HOME)/.claude/CONSTITUTION.md

--- a/bin/claude-tmux-later
+++ b/bin/claude-tmux-later
@@ -120,7 +120,7 @@ def connection():
 
 
 def process(pid):
-    result = subprocess.run(["ps", "-p", str(pid), "-o",
+    result = subprocess.run(["ps", "-ww", "-p", str(pid), "-o",
                              "ppid=,pgid=,tpgid=,tty=,lstart=,args="],
                             capture_output=True, text=True, timeout=2,
                             env=os.environ | {"LC_ALL": "C"})

--- a/bin/claude-tmux-later
+++ b/bin/claude-tmux-later
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Archive idle Claude tmux windows after 1h; close after 24h total idle.
+
+Configured by make claude; hooks start one monitor per tmux server.
+Inspect inside tmux: ~/.files/bin/claude-tmux-later status
+See docs/tmux.md for configuration, safety limits, and resuming conversations.
+"""
+import argparse
+import contextlib
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import time
+
+ROOT = Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local/state")) / "claude-tmux-later"
+CONFIG = Path.home() / ".config/claude-tmux-later/config.json"
+EVENTS = ("SessionStart", "SessionEnd", "UserPromptSubmit", "PreToolUse",
+          "PostToolUse", "PostToolUseFailure", "PreCompact", "Stop",
+          "StopFailure", "SubagentStart", "SubagentStop")
+DEFAULTS = {"enabled": True, "archive_seconds": 3600, "close_seconds": 86400,
+            "poll_seconds": 60, "later_session": "later", "dry_run": False}
+
+
+def read_json(path, default):
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError:
+        return default
+
+
+def write_json(path, data):
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    temp = path.with_name(path.name + ".tmp")
+    with temp.open("w") as stream:
+        os.chmod(temp, 0o600)
+        json.dump(data, stream, indent=2)
+        stream.write("\n")
+    temp.replace(path)
+
+
+@contextlib.contextmanager
+def locked(path, nonblocking=False):
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    with path.open("a") as stream:
+        fcntl.flock(stream, fcntl.LOCK_EX | (fcntl.LOCK_NB if nonblocking else 0))
+        yield
+
+
+def settings():
+    cfg = DEFAULTS | read_json(CONFIG, {})
+    if not all(isinstance(cfg[k], bool) for k in ("enabled", "dry_run")):
+        raise ValueError("enabled and dry_run must be JSON booleans")
+    if not (0 < cfg["archive_seconds"] < cfg["close_seconds"]):
+        raise ValueError("Require 0 < archive_seconds < close_seconds")
+    if not (1 <= cfg["poll_seconds"] <= 60):
+        raise ValueError("poll_seconds must be between 1 and 60")
+    if not re.fullmatch(r"[A-Za-z0-9_-]+", cfg["later_session"]):
+        raise ValueError("later_session must contain letters, digits, _ or -")
+    return cfg
+
+
+class Tmux:
+    def __init__(self, socket, executable="tmux"):
+        self.socket, self.executable = socket, executable
+
+    def call(self, *args):
+        result = subprocess.run([self.executable, "-S", self.socket, *args],
+                                text=True, capture_output=True, timeout=3)
+        if result.returncode:
+            raise RuntimeError(result.stderr.strip() or "tmux command failed")
+        return result.stdout.rstrip("\n")
+
+    def identity(self):
+        return self.call("display-message", "-p", "#{pid}:#{start_time}")
+
+    def panes(self):
+        fields = ("session_id", "session_name", "window_id", "pane_id",
+                  "pane_current_command", "pane_dead", "pane_in_mode",
+                  "window_linked", "@claude_later_pin", "pane_tty")
+        fmt = "\t".join("#{" + field + "}" for field in fields)
+        rows = self.call("list-panes", "-a", "-F", fmt)
+        return [dict(zip(fields, row.split("\t"))) for row in rows.splitlines()]
+
+    def visible_windows(self):
+        return set(self.call("list-clients", "-F", "#{window_id}").splitlines())
+
+    def move(self, row, name):
+        # Resolve exact session names, then use IDs. Never overwrite a window.
+        sessions = self.call("list-sessions", "-F", "#{session_id}\t#{session_name}")
+        target = next((s.split("\t")[0] for s in sessions.splitlines()
+                       if s.split("\t", 1)[1] == name), None)
+        placeholder = None
+        if target is None:
+            created = self.call("new-session", "-d", "-s", name, "-n", "holding",
+                                "-P", "-F", "#{session_id}\t#{window_id}",
+                                "/bin/sh", "-c", "exec sleep 2147483647")
+            target, placeholder = created.split("\t")
+        self.call("move-window", "-d", "-s", row["window_id"], "-t", target + ":")
+        if placeholder:
+            self.call("kill-window", "-t", placeholder)
+
+
+def connection():
+    raw = os.environ.get("TMUX", "")
+    if not raw:
+        raise RuntimeError("Run this command inside tmux")
+    socket = raw.rsplit(",", 2)[0]
+    tmux = Tmux(socket)
+    ident = tmux.identity()
+    key = hashlib.sha256((socket + "\0" + ident).encode()).hexdigest()[:24]
+    folder = ROOT / key
+    folder.mkdir(parents=True, exist_ok=True, mode=0o700)
+    return tmux, ident, folder
+
+
+def process(pid):
+    result = subprocess.run(["ps", "-p", str(pid), "-o",
+                             "ppid=,pgid=,tpgid=,tty=,lstart=,args="],
+                            capture_output=True, text=True, timeout=2,
+                            env=os.environ | {"LC_ALL": "C"})
+    parts = result.stdout.strip().split(None, 9)
+    if result.returncode or len(parts) != 10:
+        return None
+    return {"pid": int(pid), "ppid": int(parts[0]),
+            "pgid": int(parts[1]), "tpgid": int(parts[2]), "tty": parts[3],
+            # claude-wrapper pins argv[0]; the native executable's comm can
+            # instead be a versioned binary name on macOS. Never log the args.
+            "started": " ".join(parts[4:9]), "command": parts[9].split()[0]}
+
+
+def claude_ancestor():
+    pid = os.getppid()
+    for _ in range(16):
+        p = process(pid)
+        if not p:
+            return None
+        if Path(p["command"]).name == "claude":
+            return {"pid": pid, "started": p["started"]}
+        pid = p["ppid"]
+        if pid <= 1:
+            return None
+    return None
+
+
+def foreground_owner(row, state):
+    """Require the recorded native Claude process to own the pane foreground."""
+    owner = state.get("owner")
+    if not owner:
+        return False
+    p = process(owner["pid"])
+    if not p or p["started"] != owner["started"] or Path(p["command"]).name != "claude":
+        return False
+    # A detached monitor cannot tcgetpgrp() another session's controlling
+    # terminal on Linux. ps exposes the foreground group without opening it.
+    tty = p["tty"].removeprefix("/dev/")
+    # A nested observer may share its parent's foreground process group. Only
+    # the group leader is the interactive CLI launched by claude-wrapper.
+    return (p["pid"] == p["pgid"] == p["tpgid"] and p["tpgid"] > 0 and
+            tty == row["pane_tty"].removeprefix("/dev/"))
+
+
+def transition(previous, event, now, owner=None):
+    """Pure hook state transition; no transcript or prompt content is retained."""
+    kind, sid = event.get("hook_event_name"), event.get("session_id")
+    agent = event.get("agent_id")
+    if not sid or (agent and kind not in ("SubagentStart", "SubagentStop")):
+        return previous
+    if not previous or previous.get("session_id") != sid:
+        if kind != "SessionStart" or owner is None:
+            return previous
+        previous = {"session_id": sid, "owner": owner, "phase": "idle",
+                    "agents": [], "background": True}
+    s = dict(previous)
+    if kind == "SessionEnd":
+        return None
+    s["last_activity"] = now
+    s["cwd"] = event.get("cwd", s.get("cwd", ""))
+    s["transcript_path"] = event.get("transcript_path", s.get("transcript_path", ""))
+    if kind == "SessionStart":
+        # No work has started on a fresh interactive session; on compaction
+        # retain busy state until an actual Stop confirms completion.
+        if event.get("source") != "compact":
+            s.update(phase="idle", background=False, agents=[], owner=owner)
+    elif kind in ("UserPromptSubmit", "PreToolUse", "PostToolUse",
+                  "PostToolUseFailure", "PreCompact"):
+        s["phase"] = "busy"
+    elif kind == "Stop":
+        s["phase"] = "idle"
+        # Missing registry fields mean activity cannot be established safely.
+        s["background"] = (event.get("background_tasks") != [] or
+                           event.get("session_crons") != [])
+    elif kind == "StopFailure":
+        s["phase"] = "unknown"
+    elif kind in ("SubagentStart", "SubagentStop"):
+        agents = set(s.get("agents", []))
+        if kind == "SubagentStart":
+            agents.add(agent or "unknown")
+        else:
+            agents.discard(agent)
+        s["agents"] = sorted(agents)
+    return s
+
+
+def decision(rows, states, visible, now, cfg):
+    """All panes must be idle, managed Claude panes before acting on a window."""
+    if rows[0]["window_id"] in visible:
+        return None, "viewed"
+    if any(r["window_linked"] != "0" or r["@claude_later_pin"] in ("1", "on", "true")
+           or r["pane_dead"] != "0" or r["pane_in_mode"] != "0" for r in rows):
+        return None, "pinned, linked, dead, or in copy mode"
+    tracked = [states.get(r["pane_id"]) for r in rows]
+    if any(not s for s in tracked):
+        return None, "contains an unmanaged pane"
+    if any(s["phase"] != "idle" or s.get("background", True) or s.get("agents")
+           for s in tracked):
+        return None, "busy or activity unknown"
+    age = min(now - s["last_activity"] for s in tracked)
+    if age < cfg["archive_seconds"]:
+        return None, f"idle {max(0, int(age))}s"
+    if rows[0]["session_name"] != cfg["later_session"]:
+        return "move", f"idle {int(age)}s"
+    if age >= cfg["close_seconds"]:
+        return "close", f"idle {int(age)}s"
+    return None, f"parked; idle {int(age)}s"
+
+
+def record(folder, action, rows, states):
+    entry = {"at": time.time(), "action": action, "window_id": rows[0]["window_id"],
+             "session": rows[0]["session_name"],
+             "conversations": [{k: states[r["pane_id"]].get(k)
+                                 for k in ("session_id", "cwd", "transcript_path")}
+                                for r in rows]}
+    with (folder / "history.jsonl").open("a") as stream:
+        stream.write(json.dumps(entry) + "\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+
+
+def sweep(tmux, folder, cfg, inspect=False):
+    with locked(folder / "state.lock"):
+        states = read_json(folder / "state.json", {})
+        panes, visible = tmux.panes(), tmux.visible_windows()
+        windows = {}
+        for row in panes:
+            windows.setdefault(row["window_id"], []).append(row)
+        for wid, rows in windows.items():
+            if not any(r["pane_id"] in states for r in rows):
+                continue
+            action, reason = decision(rows, states, visible, time.time(), cfg)
+            if action and not all(foreground_owner(r, states[r["pane_id"]]) for r in rows):
+                action, reason = None, "Claude process ownership unverified"
+            if inspect:
+                print(f'{rows[0]["session_name"]}:{wid} {action or "keep"}: {reason}')
+            if not action or inspect:
+                continue
+            if cfg["dry_run"]:
+                record(folder, "would-" + action, rows, states)
+                continue
+            # Recheck client selection and pane composition immediately before
+            # mutation. The same lock serializes prompt hooks with this sweep.
+            fresh = [r for r in tmux.panes() if r["window_id"] == wid]
+            if fresh != rows or wid in tmux.visible_windows():
+                continue
+            if not all(foreground_owner(r, states[r["pane_id"]]) for r in fresh):
+                continue
+            record(folder, action + "-requested", rows, states)
+            if action == "move":
+                tmux.move(rows[0], cfg["later_session"])
+            else:
+                tmux.call("kill-window", "-t", wid)
+                for row in rows:
+                    states.pop(row["pane_id"], None)
+            record_states = read_json(folder / "state.json", {})
+            record(folder, action + "-completed", rows, record_states)
+        live = {r["pane_id"] for r in panes}
+        states = {pane: s for pane, s in states.items() if pane in live}
+        if not inspect:
+            write_json(folder / "state.json", states)
+
+
+def ensure_daemon(tmux, ident, folder):
+    try:
+        with locked(folder / "daemon.lock", nonblocking=True):
+            pass
+    except BlockingIOError:
+        return
+    with (folder / "daemon.log").open("a") as log:
+        subprocess.Popen([sys.executable, str(Path(__file__).resolve()), "daemon",
+                          "--socket", tmux.socket, "--identity", ident,
+                          "--folder", str(folder), "--tmux", shutil.which("tmux") or "tmux"],
+                         stdin=subprocess.DEVNULL, stdout=log, stderr=log,
+                         start_new_session=True, close_fds=True,
+                         env={k: v for k, v in os.environ.items()
+                              if k not in ("TMUX", "TMUX_PANE")})
+
+
+def hook():
+    cfg = settings()
+    if not cfg["enabled"] or not os.environ.get("TMUX_PANE"):
+        return
+    event = json.load(sys.stdin)
+    tmux, ident, folder = connection()
+    pane = os.environ["TMUX_PANE"]
+    owner = claude_ancestor() if event.get("hook_event_name") == "SessionStart" else None
+    if event.get("hook_event_name") == "SessionStart":
+        # claude-mem and other nested processes inherit TMUX_PANE. Never let
+        # their SessionStart replace the actual foreground conversation.
+        row = next((r for r in tmux.panes() if r["pane_id"] == pane), None)
+        if row is None or not foreground_owner(row, {"owner": owner}):
+            return
+    with locked(folder / "state.lock"):
+        states = read_json(folder / "state.json", {})
+        updated = transition(states.get(pane), event, time.time(), owner)
+        if updated:
+            states[pane] = updated
+        else:
+            states.pop(pane, None)
+        write_json(folder / "state.json", states)
+    ensure_daemon(tmux, ident, folder)
+
+
+def daemon(args):
+    tmux, folder = Tmux(args.socket, args.tmux), Path(args.folder)
+    try:
+        with locked(folder / "daemon.lock", nonblocking=True):
+            while True:
+                cfg = settings()
+                if not cfg["enabled"]:
+                    return
+                try:
+                    if tmux.identity() != args.identity:
+                        return
+                except (RuntimeError, subprocess.TimeoutExpired):
+                    return
+                try:
+                    sweep(tmux, folder, cfg)
+                except (RuntimeError, OSError, ValueError, subprocess.TimeoutExpired) as exc:
+                    print(f"Sweep skipped: {exc}", file=sys.stderr, flush=True)
+                time.sleep(cfg["poll_seconds"])
+    except BlockingIOError:
+        return
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("hook")
+    sub.add_parser("status")
+    sub.add_parser("sweep")
+    p = sub.add_parser("daemon")
+    for name in ("socket", "identity", "folder", "tmux"):
+        p.add_argument("--" + name, required=True)
+    args = parser.parse_args()
+    if args.command == "hook":
+        # A cleanup problem must not block Claude or inject text into its context.
+        try:
+            hook()
+        except Exception as exc:
+            print(f"claude-tmux-later hook skipped: {type(exc).__name__}", file=sys.stderr)
+    elif args.command == "daemon":
+        daemon(args)
+    else:
+        tmux, _, folder = connection()
+        cfg = settings()
+        if cfg["enabled"] or args.command == "status":
+            sweep(tmux, folder, cfg, inspect=args.command == "status")
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/claude-tmux-later_test.py
+++ b/bin/claude-tmux-later_test.py
@@ -1,0 +1,383 @@
+"""Behavioral tests for automatic termination and lifecycle boundaries."""
+import contextlib
+import importlib.util
+from importlib.machinery import SourceFileLoader
+import io
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import tempfile
+import time
+from types import SimpleNamespace
+import unittest
+from unittest.mock import patch
+
+SCRIPT = Path(__file__).with_name("claude-tmux-later")
+loader = SourceFileLoader("claude_tmux_later", str(SCRIPT))
+spec = importlib.util.spec_from_loader(loader.name, loader)
+app = importlib.util.module_from_spec(spec)
+loader.exec_module(app)
+
+
+NOW = 200000
+
+
+def pane(pid="%7", session="main", window="@4"):
+    return dict(session_id="$1", session_name=session, window_id=window,
+                pane_id=pid, pane_current_command="claude", pane_dead="0",
+                pane_in_mode="0", window_linked="0", pane_tty="/dev/pts/7",
+                **{"@claude_later_pin": ""})
+
+
+def state(age=3600):
+    return dict(session_id="conversation-1", phase="idle", agents=[],
+                background=False, last_activity=NOW-age, cwd="/project",
+                owner={"pid": 42, "started": "Fri Sep 11 05:00:00 2026"},
+                transcript_path="/tmp/conversation-1.jsonl")
+
+
+class PolicyTests(unittest.TestCase):
+    def decide(self, row=None, value=None, visible=None):
+        row = row or pane()
+        return app.decision([row], {row["pane_id"]: value or state()},
+                            visible or set(), NOW, app.DEFAULTS)[0]
+
+    def test_exact_one_hour_boundary(self):
+        self.assertIsNone(self.decide(value=state(3599)))
+        self.assertEqual(self.decide(value=state(3600)), "move")
+
+    def test_24_hours_is_total_idle_not_time_in_later(self):
+        self.assertIsNone(self.decide(pane(session="later"), state(86399)))
+        self.assertEqual(self.decide(pane(session="later"), state(86400)), "close")
+
+    def test_unparked_old_window_moves_before_any_close(self):
+        self.assertEqual(self.decide(value=state(100000)), "move")
+
+    def test_viewing_prevents_both_actions(self):
+        for session in ("main", "later"):
+            self.assertIsNone(self.decide(pane(session=session), state(100000), {"@4"}))
+
+    def test_busy_forever_does_not_age_into_termination(self):
+        for phase in ("busy", "unknown"):
+            self.assertIsNone(self.decide(pane(session="later"), state(100000) | {"phase": phase}))
+
+    def test_background_work_or_agents_prevents_cleanup(self):
+        for extra in ({"background": True}, {"agents": ["agent-a"]}):
+            self.assertIsNone(self.decide(pane(session="later"), state(100000) | extra))
+
+    def test_mixed_window_is_preserved(self):
+        rows = [pane(), pane("%8")]
+        self.assertIsNone(app.decision(rows, {"%7": state()}, set(), NOW, app.DEFAULTS)[0])
+
+    def test_youngest_pane_controls_clock(self):
+        rows = [pane(), pane("%8")]
+        states = {"%7": state(100000), "%8": state(20)}
+        self.assertIsNone(app.decision(rows, states, set(), NOW, app.DEFAULTS)[0])
+
+    def test_all_managed_panes_may_archive_together(self):
+        rows = [pane(), pane("%8")]
+        states = {"%7": state(4000), "%8": state(3600)}
+        self.assertEqual(app.decision(rows, states, set(), NOW, app.DEFAULTS)[0], "move")
+
+    def test_pin_link_copy_mode_and_dead_pane_prevent_close(self):
+        for field in ("@claude_later_pin", "window_linked", "pane_in_mode", "pane_dead"):
+            self.assertIsNone(self.decide(pane(session="later") | {field: "1"}, state(100000)))
+
+    def test_clock_going_backwards_delays_cleanup(self):
+        self.assertIsNone(self.decide(value=state(-10)))
+
+
+class HookTests(unittest.TestCase):
+    def event(self, kind, **fields):
+        return dict(hook_event_name=kind, session_id="conversation-1", **fields)
+
+    def test_new_prompt_cancels_old_idle_eligibility(self):
+        s = app.transition(state(100000), self.event("UserPromptSubmit"), NOW)
+        self.assertEqual(s["phase"], "busy")
+        self.assertEqual(s["last_activity"], NOW)
+        s = app.transition(s, self.event("Stop", background_tasks=[], session_crons=[]), NOW+10)
+        self.assertNotEqual(app.decision([pane(session="later")], {"%7": s}, set(),
+                                        NOW+86409, app.DEFAULTS)[0], "close")
+        self.assertEqual(app.decision([pane(session="later")], {"%7": s}, set(),
+                                     NOW+86410, app.DEFAULTS)[0], "close")
+        self.assertEqual(s["last_activity"], NOW+10)
+
+    def test_unknown_background_state_blocks_termination(self):
+        s = app.transition(state(), self.event("Stop"), NOW)
+        self.assertTrue(s["background"])
+
+    def test_background_tasks_and_scheduled_prompts_protect_session(self):
+        for field in ("background_tasks", "session_crons"):
+            fields = {"background_tasks": [], "session_crons": []}
+            fields[field] = [{"id": "scheduled-work"}]
+            self.assertTrue(app.transition(state(), self.event("Stop", **fields), NOW)["background"])
+
+    def test_subagent_tool_hooks_cannot_change_parent_phase(self):
+        s = state() | {"phase": "busy"}
+        for kind in ("Stop", "SessionEnd", "SessionStart"):
+            self.assertEqual(app.transition(s, self.event(kind, agent_id="child"), NOW), s)
+
+    def test_subagent_start_and_stop_keep_parent_state(self):
+        s = app.transition(state(), self.event("SubagentStart", agent_id="child"), NOW)
+        self.assertEqual(s["agents"], ["child"])
+        s = app.transition(s, self.event("SubagentStop", agent_id="child"), NOW+10)
+        self.assertEqual(s["agents"], [])
+        self.assertEqual(s["last_activity"], NOW+10)
+
+    def test_late_event_from_previous_conversation_does_not_delete_new_one(self):
+        e = self.event("SessionEnd") | {"session_id": "old-session"}
+        self.assertEqual(app.transition(state(), e, NOW), state())
+
+    def test_session_end_removes_registration(self):
+        self.assertIsNone(app.transition(state(), self.event("SessionEnd"), NOW))
+
+    def test_cannot_enroll_without_verified_claude_process(self):
+        self.assertIsNone(app.transition(None, self.event("SessionStart", source="startup"), NOW))
+
+    def test_compaction_start_does_not_mark_busy_session_idle(self):
+        s = state() | {"phase": "busy"}
+        result = app.transition(s, self.event("SessionStart", source="compact"), NOW, s["owner"])
+        self.assertEqual(result["phase"], "busy")
+
+    def test_api_failure_is_unknown_until_later_successful_stop(self):
+        self.assertEqual(app.transition(state(), self.event("StopFailure"), NOW)["phase"], "unknown")
+
+
+class FakeTmux:
+    def __init__(self, row, folder):
+        self.row, self.folder, self.calls = row, folder, []
+        self.visibility_calls = 0
+        self.become_visible = False
+
+    def panes(self):
+        return [self.row.copy()]
+
+    def visible_windows(self):
+        self.visibility_calls += 1
+        return {"@4"} if self.become_visible and self.visibility_calls > 1 else set()
+
+    def move(self, row, name):
+        self.calls.append(("move", row["window_id"], name))
+        self.row["session_name"] = name
+
+    def call(self, *args):
+        # The resume record must exist before sending kill-window.
+        history = (self.folder / "history.jsonl").read_text()
+        assert '"session_id": "conversation-1"' in history
+        assert '"action": "close-requested"' in history
+        self.calls.append(args)
+
+
+class SweepTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.folder = Path(self.temp.name)
+        app.write_json(self.folder / "state.json", {"%7": state(86400)})
+        self.tmux = FakeTmux(pane(session="later"), self.folder)
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def run_sweep(self, cfg=None, inspect=False, owner=True):
+        with patch.object(app.time, "time", return_value=NOW), \
+             patch.object(app, "foreground_owner", return_value=owner), \
+             contextlib.redirect_stdout(io.StringIO()):
+            app.sweep(self.tmux, self.folder, cfg or app.DEFAULTS, inspect=inspect)
+
+    def test_close_logs_resume_identity_before_kill_and_unregisters_pane(self):
+        self.run_sweep()
+        self.assertEqual(self.tmux.calls, [("kill-window", "-t", "@4")])
+        self.assertEqual(app.read_json(self.folder / "state.json", {}), {})
+        events = [json.loads(x)["action"] for x in (self.folder / "history.jsonl").read_text().splitlines()]
+        self.assertEqual(events, ["close-requested", "close-completed"])
+
+    def test_move_keeps_process_state_and_idle_clock(self):
+        self.tmux.row["session_name"] = "main"
+        self.run_sweep()
+        self.assertEqual(self.tmux.calls, [("move", "@4", "later")])
+        self.assertEqual(app.read_json(self.folder / "state.json", {})["%7"]["last_activity"], NOW-86400)
+
+    def test_dry_run_and_status_never_mutate_tmux(self):
+        for cfg, inspect in ((app.DEFAULTS | {"dry_run": True}, False), (app.DEFAULTS, True)):
+            self.run_sweep(cfg, inspect)
+            self.assertEqual(self.tmux.calls, [])
+            self.assertIn("%7", app.read_json(self.folder / "state.json", {}))
+
+    def test_client_switching_to_window_before_kill_cancels_it(self):
+        self.tmux.become_visible = True
+        self.run_sweep()
+        self.assertEqual(self.tmux.calls, [])
+
+    def test_pid_reuse_or_unverifiable_foreground_prevents_kill(self):
+        self.run_sweep(owner=False)
+        self.assertEqual(self.tmux.calls, [])
+
+
+class ConfigurationTests(unittest.TestCase):
+    def test_all_lifecycle_hooks_are_wired_once(self):
+        doc = app.read_json(SCRIPT.parent.parent / ".claude/settings.json", {})
+        for event in app.EVENTS:
+            hooks = [h for entry in doc["hooks"][event] for h in entry["hooks"]
+                     if "claude-tmux-later" in h.get("command", "")]
+            self.assertEqual(len(hooks), 1, event)
+            self.assertEqual(hooks[0]["command"], '"$HOME/.files/bin/claude-tmux-later" hook')
+            self.assertFalse(hooks[0].get("async", False))
+
+    def test_checked_in_defaults_match_runtime_defaults(self):
+        self.assertEqual(app.read_json(SCRIPT.parent.parent / "claude/tmux-later.json", {}),
+                         app.DEFAULTS)
+
+    def test_observer_session_start_does_not_replace_foreground_session(self):
+        with tempfile.TemporaryDirectory() as folder:
+            root = Path(folder)
+            app.write_json(root / "state.json", {"%7": state()})
+            tmux = FakeTmux(pane(), root)
+            event = dict(hook_event_name="SessionStart", session_id="observer", source="startup")
+            with patch.dict(app.os.environ, {"TMUX": "/tmp/tmux,1,0", "TMUX_PANE": "%7"}), \
+                 patch.object(app.sys, "stdin", io.StringIO(json.dumps(event))), \
+                 patch.object(app, "settings", return_value=app.DEFAULTS), \
+                 patch.object(app, "connection", return_value=(tmux, "1:1", root)), \
+                 patch.object(app, "claude_ancestor", return_value={"pid": 99, "started": "now"}), \
+                 patch.object(app, "foreground_owner", return_value=False), \
+                 patch.object(app, "ensure_daemon") as daemon:
+                app.hook()
+                daemon.assert_not_called()
+            self.assertEqual(app.read_json(root / "state.json", {}), {"%7": state()})
+
+
+class ProcessTests(unittest.TestCase):
+    def test_native_process_foreground_is_verified_without_controlling_tty(self):
+        for tty, command in (("pts/7", "claude"), ("ttys007", "/Users/josh/.local/bin/claude")):
+            line = f"1 42 42 {tty} Fri Sep 11 05:00:00 2026 {command}\n"
+            result = SimpleNamespace(returncode=0, stdout=line)
+            with patch.object(app.subprocess, "run", return_value=result):
+                self.assertTrue(app.foreground_owner(pane() | {"pane_tty": "/dev/"+tty}, state()))
+
+    def test_background_process_with_matching_name_cannot_be_closed(self):
+        result = SimpleNamespace(returncode=0,
+                                 stdout="1 42 99 pts/7 Fri Sep 11 05:00:00 2026 claude\n")
+        with patch.object(app.subprocess, "run", return_value=result):
+            self.assertFalse(app.foreground_owner(pane(), state()))
+
+    def test_reused_pid_with_different_start_time_cannot_be_closed(self):
+        result = SimpleNamespace(returncode=0,
+                                 stdout="1 42 42 pts/7 Fri Sep 11 06:00:00 2026 claude\n")
+        with patch.object(app.subprocess, "run", return_value=result):
+            self.assertFalse(app.foreground_owner(pane(), state()))
+
+    def test_observer_sharing_foreground_process_group_is_not_owner(self):
+        result = SimpleNamespace(returncode=0,
+                                 stdout="42 42 42 pts/7 Fri Sep 11 05:00:00 2026 claude\n")
+        with patch.object(app.subprocess, "run", return_value=result):
+            self.assertFalse(app.foreground_owner(pane(), state() | {
+                "owner": {"pid": 99, "started": "Fri Sep 11 05:00:00 2026"}}))
+
+    def test_versioned_native_executable_uses_wrapper_argv_zero(self):
+        result = SimpleNamespace(returncode=0,
+                                 stdout="1 42 42 pts/7 Fri Sep 11 05:00:00 2026 claude --resume id\n")
+        with patch.object(app.subprocess, "run", return_value=result):
+            self.assertTrue(app.foreground_owner(pane() | {"pane_current_command": "2.1.242"}, state()))
+
+
+class TmuxAvailabilityTests(unittest.TestCase):
+    def test_ci_requires_live_tmux_tests(self):
+        if os.environ.get("REQUIRE_TMUX_TESTS") == "1":
+            self.assertIsNotNone(shutil.which("tmux"))
+
+
+@unittest.skipUnless(shutil.which("tmux"), "tmux is not installed")
+class LiveTmuxTests(unittest.TestCase):
+    """Use only a private socket, an empty config, and disposable sleep panes."""
+
+    def setUp(self):
+        # Short socket path also fits Darwin's sockaddr_un limit.
+        self.temp = tempfile.TemporaryDirectory(prefix="claude-later-", dir="/tmp")
+        self.folder = Path(self.temp.name)
+        self.tmux = app.Tmux(str(self.folder / "server.sock"))
+        env = {k: v for k, v in os.environ.items() if k not in ("TMUX", "TMUX_PANE")}
+        subprocess.run(["tmux", "-S", self.tmux.socket, "-f", "/dev/null",
+                        "new-session", "-d", "-s", "main", "-n", "keep", "sleep 300"],
+                       check=True, capture_output=True, env=env, timeout=5)
+        self.claude = self.folder / "claude"
+        shutil.copy2(shutil.which("sleep"), self.claude)
+        self.client = None
+
+    def tearDown(self):
+        # This cannot reach the user's default server or any unrelated socket.
+        subprocess.run(["tmux", "-S", self.tmux.socket, "kill-server"],
+                       capture_output=True, timeout=5)
+        if self.client:
+            self.client.communicate(timeout=5)
+        self.temp.cleanup()
+
+    def new_claude(self, age=3600):
+        pane_id = self.tmux.call("new-window", "-d", "-t", "main:", "-P", "-F", "#{pane_id}",
+                                 f"exec {shlex.quote(str(self.claude))} 300")
+        pid = int(self.tmux.call("display-message", "-p", "-t", pane_id, "#{pane_pid}"))
+        deadline = time.monotonic() + 3
+        while time.monotonic() < deadline:
+            p = app.process(pid)
+            row = next(r for r in self.tmux.panes() if r["pane_id"] == pane_id)
+            s = state(age) | {"owner": {"pid": pid, "started": p["started"] if p else ""}}
+            if p and app.foreground_owner(row, s):
+                app.write_json(self.folder / "state.json", {pane_id: s})
+                return row
+            time.sleep(0.02)
+        self.fail("Disposable native Claude fixture never owned its tmux foreground")
+
+    def sweep(self, now=NOW, **overrides):
+        with patch.object(app.time, "time", return_value=now):
+            app.sweep(self.tmux, self.folder, app.DEFAULTS | overrides)
+
+    def test_window_moves_then_closes_at_total_idle_deadline(self):
+        row = self.new_claude()
+        self.sweep()
+        moved = next(r for r in self.tmux.panes() if r["pane_id"] == row["pane_id"])
+        self.assertEqual(moved["session_name"], "later")
+        self.assertEqual(moved["window_id"], row["window_id"])
+        self.assertTrue(app.foreground_owner(moved, app.read_json(self.folder / "state.json", {})[row["pane_id"]]))
+        self.sweep(NOW + 86400 - 3600 - 1)
+        self.assertIn(row["pane_id"], [r["pane_id"] for r in self.tmux.panes()])
+        self.sweep(NOW + 86400 - 3600)
+        self.assertNotIn(row["pane_id"], [r["pane_id"] for r in self.tmux.panes()])
+        self.assertIn("main", [r["session_name"] for r in self.tmux.panes()])
+        self.assertIn("conversation-1", (self.folder / "history.jsonl").read_text())
+
+    def test_existing_later_window_is_not_overwritten(self):
+        existing = self.tmux.call("new-session", "-d", "-s", "later", "-P", "-F", "#{pane_id}", "sleep 300")
+        row = self.new_claude()
+        self.sweep()
+        later = [r for r in self.tmux.panes() if r["session_name"] == "later"]
+        self.assertEqual({r["pane_id"] for r in later}, {existing, row["pane_id"]})
+
+    def test_mixed_and_busy_windows_are_untouched(self):
+        row = self.new_claude(age=100000)
+        self.tmux.call("split-window", "-d", "-t", row["pane_id"], "sleep 300")
+        self.sweep()
+        self.assertEqual({r["session_name"] for r in self.tmux.panes()}, {"main"})
+        states = app.read_json(self.folder / "state.json", {})
+        states[row["pane_id"]]["phase"] = "busy"
+        app.write_json(self.folder / "state.json", states)
+        self.sweep()
+        self.assertEqual({r["session_name"] for r in self.tmux.panes()}, {"main"})
+
+    def test_viewed_parked_window_is_not_closed(self):
+        row = self.new_claude(age=100000)
+        self.sweep()
+        self.tmux.call("select-window", "-t", row["window_id"])
+        self.client = subprocess.Popen(["tmux", "-S", self.tmux.socket, "-C", "attach-session", "-t", "later"],
+                                       stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                       stderr=subprocess.PIPE, text=True)
+        deadline = time.monotonic() + 3
+        while row["window_id"] not in self.tmux.visible_windows() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        self.assertIn(row["window_id"], self.tmux.visible_windows())
+        self.sweep()
+        self.assertIn(row["pane_id"], [r["pane_id"] for r in self.tmux.panes()])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bin/claude-tmux-later_test.py
+++ b/bin/claude-tmux-later_test.py
@@ -295,23 +295,26 @@ class LiveTmuxTests(unittest.TestCase):
     def setUp(self):
         # Short socket path also fits Darwin's sockaddr_un limit.
         self.temp = tempfile.TemporaryDirectory(prefix="claude-later-", dir="/tmp")
+        self.addCleanup(self.temp.cleanup)
         self.folder = Path(self.temp.name)
         self.tmux = app.Tmux(str(self.folder / "server.sock"))
+        self.client = None
+        self.addCleanup(self.stop_server)
         env = {k: v for k, v in os.environ.items() if k not in ("TMUX", "TMUX_PANE")}
         subprocess.run(["tmux", "-S", self.tmux.socket, "-f", "/dev/null",
                         "new-session", "-d", "-s", "main", "-n", "keep", "sleep 300"],
                        check=True, capture_output=True, env=env, timeout=5)
         self.claude = self.folder / "claude"
-        shutil.copy2(shutil.which("sleep"), self.claude)
-        self.client = None
+        # Copy executable bytes, not macOS's protected system-file flags.
+        shutil.copyfile(shutil.which("sleep"), self.claude)
+        self.claude.chmod(0o755)
 
-    def tearDown(self):
+    def stop_server(self):
         # This cannot reach the user's default server or any unrelated socket.
         subprocess.run(["tmux", "-S", self.tmux.socket, "kill-server"],
                        capture_output=True, timeout=5)
         if self.client:
             self.client.communicate(timeout=5)
-        self.temp.cleanup()
 
     def new_claude(self, age=3600):
         pane_id = self.tmux.call("new-window", "-d", "-t", "main:", "-P", "-F", "#{pane_id}",

--- a/claude/tmux-later.json
+++ b/claude/tmux-later.json
@@ -1,0 +1,8 @@
+{
+  "enabled": true,
+  "archive_seconds": 3600,
+  "close_seconds": 86400,
+  "poll_seconds": 60,
+  "later_session": "later",
+  "dry_run": false
+}

--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -37,6 +37,83 @@ tmux-sessions <subcommand> [arg]
 
 Index numbers from `list` are valid arguments to `show` and `restore`.
 
+## Idle Claude windows → `later` → closed
+
+`bin/claude-tmux-later` moves idle Claude windows into the existing `later`
+session after **one hour** and closes parked windows after **24 hours total
+idle** (not another 24 hours after parking). It complements the manual
+`prefix+H` binding. No requests are sent to Claude to maintain the timer.
+
+`make claude` links `claude/tmux-later.json` to
+`~/.config/claude-tmux-later/config.json`; `.claude/settings.json` wires the
+lifecycle hooks alongside the existing naming and notification hooks. Start
+new Claude processes, or exit and resume existing conversations, to enroll
+them. Hooks start one detached monitor per tmux server, polling once a minute.
+There is no separate installer, cron entry, or tmux configuration change.
+
+| Setting | Default |
+| --- | --- |
+| `archive_seconds` | `3600` |
+| `close_seconds` | `86400` |
+| `poll_seconds` | `60` |
+| `later_session` | `later` |
+| `enabled` | `true` |
+| `dry_run` | `false` |
+
+The monitor reloads configuration each poll. Set `dry_run` to `true` to log
+proposed operations without changing tmux; set `enabled` to `false` to stop
+cleanup. Re-enabling takes effect when a new hook restarts the monitor.
+
+Idle means the main agent has finished responding and has no known active
+subagents, background work, or scheduled prompts. New prompts/tool activity
+reset the clock and mark the session busy; a successful Stop begins a new idle
+interval. Terminal repainting does not count as activity. Using a parked
+conversation resets its timer but does not automatically move it back.
+
+Safety rules:
+
+- Every pane in the window must be an enrolled, idle Claude process. Shell,
+  editor, and untracked panes prevent both moving and closing that window.
+- Viewed, pinned, linked, dead, and copy-mode windows are left alone.
+- Process ID, process start time, foreground process group, and terminal must
+  match. Inherited `TMUX_PANE` alone cannot enroll claude-mem observers.
+- Busy or uncertain states never expire into idle. An interrupted turn, API
+  failure, or missing background-task fields protects the session until a
+  subsequent successful turn or restart. Lost Stop events therefore retain
+  windows instead of terminating potentially active work.
+- Resume identifiers are recorded before `tmux kill-window`. This terminates
+  the window, not a graceful `/exit`; it does not delete project files,
+  transcripts, or worktrees. Normal persisted conversations remain resumable.
+
+Inspect or pin the current window:
+
+```sh
+~/.files/bin/claude-tmux-later status
+tmux set-option -w @claude_later_pin 1
+tmux set-option -wu @claude_later_pin  # unpin
+```
+
+Resume via `claude --resume` from the project directory, or use the exact
+session ID recorded in
+`${XDG_STATE_HOME:-~/.local/state}/claude-tmux-later/*/history.jsonl`.
+The log contains IDs, working directories, transcript paths, and action
+outcomes, not prompt text. Existing `@claude-session-id` restore metadata is
+left unchanged. The monitor exits when its tmux server exits; later hooks
+restart it when needed.
+
+Requires Python 3.9+, tmux, and a foreground native Claude process (including
+`claude-wrapper`, which pins its argument-zero name). Node/npm installations,
+SSH/container processes, and wrappers that retain the foreground process
+group are not enrolled. A current Claude release must report both
+`background_tasks` and `session_crons` in Stop hooks; absent fields are treated
+as unknown rather than as empty. This is an idle policy, not a measurement of
+the provider's prompt-cache lifetime, and does not change cache settings.
+
+Tests: `make test` includes unit and isolated live-tmux tests. The latter use
+an empty tmux config, a private socket, and disposable native test processes;
+they never use the default server or call the Claude API. They skip if tmux
+is unavailable locally; CI requires them on Linux and macOS.
+
 ## Disabled Keybinds
 
 The default resurrect keybinds (`prefix+Ctrl-s` to save, `prefix+Ctrl-r` to restore) are explicitly unbound:


### PR DESCRIPTION
## Behavior

- Move eligible Claude windows to the existing `later` session after **one hour idle**.
- Close parked windows after **24 hours total idle**, retaining exact session IDs and project/transcript paths for resuming.
- Protect busy/unknown states, background work, active subagents, viewed/pinned/linked/copy-mode windows, and windows containing unrelated panes.
- Verify process identity and foreground ownership so nested claude-mem observers cannot take over a pane's registration.

## Integration

- Add lifecycle hooks alongside the existing naming/notification hooks in `.claude/settings.json`.
- Track thresholds in `claude/tmux-later.json`, linked by `make claude`.
- One local monitor per tmux server; no standalone installer or additional scheduler.
- Preserve existing `@claude-session-id` / tmux-resurrect behavior. No model calls, cache-setting changes, or project/transcript deletion.

## Validation

- Local: **90 tests passed**, four isolated live-tmux tests skipped because this environment has no tmux executable.
- `git diff --cached --check` passed.
- CI: **94 tests passed on both Linux and macOS**, including all four isolated live-tmux tests (private sockets, empty config, disposable native processes; no Claude API calls).

## Activation and limits

After merging/pulling, run `make claude`, then start or restart/resume Claude processes inside tmux to enroll them. This PR does not install anything on the workstation.

Native foreground Claude processes are supported, including the existing `claude-wrapper`. Missing Stop background-task metadata is treated as unknown and retains the window. Closing uses `tmux kill-window`, not a graceful `/exit`. See `docs/tmux.md` for configuration, dry-run mode, pinning, and resuming.